### PR TITLE
fix(counting): handle mismatched column order in OrdinalDF.from_dataframes

### DIFF
--- a/src/lpm_fidelity/counting.py
+++ b/src/lpm_fidelity/counting.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from functools import partial
 
 import equinox as eqx
@@ -49,16 +50,27 @@ class OrdinalDF(eqx.Module):
         """
         assert len(dfs) > 0, "Must provide at least one dataframe"
 
-        # 1. check that all dataframes have same set() of columns
-        #    n.b. this counting method allows a list of 1 df, to support shared impl
-        first_columns = set(dfs[0].columns)
+        first_columns = dfs[0].columns
+        first_columns_set = set(first_columns)
+        reordered = [dfs[0]]
         for df in dfs[1:]:
-            assert set(df.columns) == first_columns, (
+            assert set(df.columns) == first_columns_set, (
                 "All dataframes must have the same columns"
             )
+            if df.columns != first_columns:
+                warnings.warn(
+                    f"Column order differs across dataframes; "
+                    f"reordering to match the first dataframe: "
+                    f"{first_columns}"
+                    f"This usually means a column was dropped"
+                    f"temporarily, and re-added at the end.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
-        # 2. concatenate dataframes vertically
-        concatenated = pl.concat(dfs, how="vertical")
+            reordered.append(df.select(first_columns))
+
+        concatenated = pl.concat(reordered, how="vertical")
 
         # 3. create an encoders dict from the concatenated dataframe
         # Use handle_unknown to map None -> -1 automatically
@@ -257,8 +269,6 @@ def harmonize_categorical_probabilities(ps_a, ps_b):
         >>> harmonize_categorical_probabilities({"a": 1.0}, {"a": 0.1, "b": 0.9})
             {"a": 1.0, "b" 0.0}, {"a": 0.1, "b": 0.9}
     """
-    import warnings
-
     warnings.warn(
         "harmonize_categorical_probabilities is deprecated. "
         "Use OrdinalDF.from_dataframes() for consistent category encoding.",

--- a/tests/test_ordinal_df.py
+++ b/tests/test_ordinal_df.py
@@ -1,3 +1,5 @@
+import warnings
+
 import jax.numpy as jnp
 import polars as pl
 import pytest
@@ -238,3 +240,23 @@ def test_ordinal_df_from_dataframes_mismatched_columns_raises():
 def test_ordinal_df_from_dataframes_empty_list_raises():
     with pytest.raises(AssertionError, match="at least one"):
         OrdinalDF.from_dataframes([])
+
+
+def test_ordinal_df_from_dataframes_different_column_order_warns_and_uses_first():
+    df1 = pl.DataFrame({"col1": ["a", "b"], "col2": ["x", "y"]})
+    df2 = pl.DataFrame({"col2": ["y", "z"], "col1": ["b", "c"]})
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        odfs = OrdinalDF.from_dataframes([df1, df2])
+        column_order_warnings = [
+            x for x in w if "column order" in str(x.message).lower()
+        ]
+        assert len(column_order_warnings) == 1
+
+    assert odfs[0].columns == ("col1", "col2")
+    assert odfs[1].columns == ("col1", "col2")
+
+    assert len(odfs[0].encoders[0].categories_[0]) == 3
+    assert len(odfs[0].encoders[1].categories_[0]) == 3
+    assert odfs[0].encoders[0] is odfs[1].encoders[0]


### PR DESCRIPTION
## Summary

- `OrdinalDF.from_dataframes` crashes with a Polars `ShapeError` when input DataFrames have identical columns in different order
- Reorders subsequent DataFrames to match the first DataFrame's column order before vertical concatenation, emitting a `UserWarning`

## BEFORE

```python
df_a = pl.DataFrame({"foo": ["a", "b"], "bar": ["x", "y"]})
df_b = pl.DataFrame({"bar": ["y", "x"], "foo": ["b", "a"]})

univariate_distances_in_data(df_a, df_b)
# ShapeError: unable to vstack, column names don't match: "foo" and "bar"
```

## AFTER

```python
df_a = pl.DataFrame({"foo": ["a", "b"], "bar": ["x", "y"]})
df_b = pl.DataFrame({"bar": ["y", "x"], "foo": ["b", "a"]})

univariate_distances_in_data(df_a, df_b)
# UserWarning: Column order differs across dataframes; reordering to match the first dataframe: ['foo', 'bar']
# ┌────────┬─────┐
# │ column ┆ tvd │
# │ ---    ┆ --- │
# │ str    ┆ f64 │
# ╞════════╪═════╡
# │ bar    ┆ 0.0 │
# │ foo    ┆ 0.0 │
# └────────┴─────┘
```

## Reviewer Validation

- [ ] `uv run pytest tests/test_ordinal_df.py::test_ordinal_df_from_dataframes_different_column_order_warns_and_uses_first` passes
- [ ] `uv run pytest tests/test_ordinal_df.py tests/test_distances.py tests/test_counting.py` — full suite green
- [ ] Warning message references the first DataFrame's column list, aiding caller diagnosis